### PR TITLE
Anropa free_env_vars efter solve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glpk-rust"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glpk-rust"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "GPL-3.0"
 description = "Rust wrapper for GLPK (GNU Linear Programming Kit) with static linking"

--- a/build.rs
+++ b/build.rs
@@ -404,6 +404,7 @@ pub struct glp_iocp {
     pub save_sol: *const c_char,
     pub alien: c_int,
     pub flip: c_int,
+    pub foo_bar: [c_double; 23],
 }
 
 impl Default for glp_iocp {
@@ -431,6 +432,7 @@ extern "C" {
     pub fn glp_mip_obj_val(lp: *mut glp_prob) -> c_double;
     pub fn glp_mip_col_val(lp: *mut glp_prob, j: c_int) -> c_double;
     pub fn glp_term_out(flag: c_int) -> c_int;
+    pub fn glp_free_env() -> c_int;
 }
 "#;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,6 +620,7 @@ pub fn solve_ilps<'a>(
 
         // Clean up
         glpk::glp_delete_prob(lp);
+        glpk::glp_free_env();
 
         Ok(solutions)
     }


### PR DESCRIPTION
Lägger till binding för glpk_free_env() som frigör minne som inte frigörs även om alla problem objekt är friade.
Från glpk docs: 

> The routine glp_free_env frees all resources used by GLPK routines (memory blocks, etc.) [..] if the application program even has deleted all problem objects, there will be several memory blocks still allocated for the internal library needs

Lägger också till padding på glp_iocp struct ([som i glpk source](https://github.com/firedrakeproject/glpk/blob/45156a549252849cad016366022aa1af50990613/src/glpk.h#L203)), är inte hundra på om det behövs, men claude föreslog det.